### PR TITLE
Build Top_URLS endpoint for API

### DIFF
--- a/app/controllers/api/v1/payload_stats_controller.rb
+++ b/app/controllers/api/v1/payload_stats_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::PayloadStatsController < ApplicationController
+  def top_urls
+    render json: @top_urls = Payload.top_urls
+  end
+end

--- a/app/controllers/api/v1/payloads_controller.rb
+++ b/app/controllers/api/v1/payloads_controller.rb
@@ -19,9 +19,6 @@ class Api::V1::PayloadsController < ApplicationController
     render json: Payload.destroy(params[:id])
   end
 
-  def top_urls
-  end
-
   private
 
   def payload_params

--- a/app/controllers/api/v1/payloads_controller.rb
+++ b/app/controllers/api/v1/payloads_controller.rb
@@ -19,6 +19,9 @@ class Api::V1::PayloadsController < ApplicationController
     render json: Payload.destroy(params[:id])
   end
 
+  def top_urls
+  end
+
   private
 
   def payload_params

--- a/app/models/payload.rb
+++ b/app/models/payload.rb
@@ -3,6 +3,18 @@ class Payload < ActiveRecord::Base
 
   after_create :generate_payload_hash
 
+  def self.last_5_days
+    where("created_at >= ?", 5.days.ago).group_by {|payload| payload.created_at.to_date }
+  end
+
+  def self.top_urls
+    last_5_days.sort.reverse.reduce({}) do |hash, (date, payloads)|
+      hash[date] = payloads.group_by {|p| p.url}
+                           .map {|url, v| {"url" => url, "visits" => v.size}}
+                           .sort_by { |e| e.values.last }.reverse; hash
+    end
+  end
+
   def generate_payload_hash
     update_attributes(payload_hash: Digest::MD5.hexdigest(payload_string))
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :payloads
+      get '/top_urls', to: 'payload_stats#top_urls'
     end
   end
 end

--- a/test/controllers/api/v1/payload_stats_controller_test.rb
+++ b/test/controllers/api/v1/payload_stats_controller_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class Api::V1::PayloadStatsControllerTest < ActionController::TestCase
+  test "#top_urls" do
+    get :top_urls, format: :json
+    top_urls = JSON.parse(response.body)
+    most_recent = top_urls[top_urls.keys.first]
+    highest_most_recent = most_recent.first
+
+    assert_response :success
+    assert_equal 2,                    most_recent.size
+    assert_equal "http://apple.com",   highest_most_recent["url"]
+    assert_equal 2,                    highest_most_recent["visits"]
+  end
+end

--- a/test/controllers/api/v1/payloads_controller_test.rb
+++ b/test/controllers/api/v1/payloads_controller_test.rb
@@ -8,9 +8,9 @@ class Api::V1::PayloadsControllerTest < ActionController::TestCase
     first_payload = payloads.first
 
     assert_response :success
-    assert_equal 2,                           payloads.count
-    assert_equal "http://apple.com",          first_payload["url"]
-    assert_equal "http://store.apple.com/us", first_payload["referrer"]
+    assert_equal 4,                            payloads.count
+    assert_equal "http://apple.com",           first_payload["url"]
+    assert_equal "http://google.apple.com/us", first_payload["referrer"]
   end
 
   test "#show" do
@@ -19,8 +19,8 @@ class Api::V1::PayloadsControllerTest < ActionController::TestCase
     payload = JSON.parse(response.body)["payload"]
 
     assert_response :success
-    assert_equal "http://apple.com",          payload["url"]
-    assert_equal "http://store.apple.com/us", payload["referrer"]
+    assert_equal "http://apple.com",           payload["url"]
+    assert_equal "http://google.apple.com/us", payload["referrer"]
   end
 
   test '#create' do

--- a/test/fixtures/payloads.yml
+++ b/test/fixtures/payloads.yml
@@ -11,3 +11,15 @@ two:
   referrer: "http://store.apple.com/us"
   payload_hash:
   created_at: '2015-04-28 01:35:23'
+
+three:
+  url: "http://apple.com"
+  referrer: "http://google.apple.com/us"
+  payload_hash:
+  created_at: '2015-04-29 01:30:23'
+
+four:
+  url: "http://www.apple.com"
+  referrer: nil
+  payload_hash:
+  created_at: '2015-04-29 03:30:23'


### PR DESCRIPTION
The Top Urls endpoint creates a report, giving the number of page views per URL, grouped by day, for the past 5 days.
