### PR TITLE
Build top_referrers endpoint for API

### DIFF
--- a/app/controllers/api/v1/payload_stats_controller.rb
+++ b/app/controllers/api/v1/payload_stats_controller.rb
@@ -1,5 +1,9 @@
 class Api::V1::PayloadStatsController < ApplicationController
   def top_urls
-    render json: @top_urls = Payload.top_urls
+    render json: @top_urls = PayloadStats.new.top_urls
+  end
+
+  def top_referrers
+    render json: @top_referrers = PayloadStats.new.top_referrers
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,0 @@
-module ApplicationHelper
-end

--- a/app/models/payload.rb
+++ b/app/models/payload.rb
@@ -3,18 +3,8 @@ class Payload < ActiveRecord::Base
 
   after_create :generate_payload_hash
 
-  def self.last_5_days
-    where("created_at >= ?", 5.days.ago).group_by {|payload| payload.created_at.to_date }
-  end
-
-  def self.top_urls
-    last_5_days.sort.reverse.reduce({}) do |hash, (date, payloads)|
-      hash[date] = payloads.group_by {|p| p.url}
-                           .map {|url, v| {"url" => url, "visits" => v.size}}
-                           .sort_by { |e| e.values.last }.reverse; hash
-    end
-  end
-
+  scope :last_5_days, -> { where("created_at >= ?", 5.days.ago) }
+  
   def generate_payload_hash
     update_attributes(payload_hash: Digest::MD5.hexdigest(payload_string))
   end

--- a/app/models/payload_stats.rb
+++ b/app/models/payload_stats.rb
@@ -1,0 +1,52 @@
+class PayloadStats
+  attr_reader :last_5_days
+  def initialize
+    @last_5_days = last_5_days_formatted
+  end
+
+  def top_urls
+    last_5_days.reduce({}) do |hash, (date, payloads)|
+      hash[date] = payloads.group_by {|p| p.url}
+                           .map {|url, v| {"url" => url, "visits" => v.size}}
+                           .sort_by { |e| e.values.last }.reverse; hash
+    end
+  end
+
+  def top_referrers
+    last_5_days.reduce({}) do |date_hash, (date, payloads)|
+      date_hash.merge(date => array_url_stats(date, payloads))
+    end
+  end
+
+  private
+
+  def last_5_days_formatted
+    Payload.last_5_days.group_by {|p| p.created_at.to_date }.sort.reverse
+  end
+  
+  def array_url_stats(date, payloads)
+    unsorted_url_array(date, payloads).sort_by{|h| h.values[1]}.reverse
+  end
+
+  def unsorted_url_array(date, payloads)
+    payloads.group_by(&:url).reduce([]) do |url_array, (url, url_values)|
+      url_array << {"url"       => url,
+                    "visits"    => url_values.size,
+                    "referrers" => referrer_array(url, url_values) }
+    end
+  end
+
+  def referrer_array(url, url_vals)
+    unsorted_ref_array(url, url_vals).sort_by{|h| h.values[1]}.reverse
+  end
+
+  def unsorted_ref_array(url, url_vals)
+    url_vals.group_by(&:referrer)
+            .reduce([]) {|refs, (ref, ref_vals)| add_ref(refs, ref, ref_vals) }
+  end
+
+  def add_ref(refs, ref, ref_vals)
+    refs << {"url" => ref, "visists" => ref_vals.size } if ref.present?
+    refs
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :payloads
       get '/top_urls', to: 'payload_stats#top_urls'
+      get '/top_referrers', to: 'payload_stats#top_referrers'
     end
   end
 end

--- a/test/controllers/api/v1/payload_stats_controller_test.rb
+++ b/test/controllers/api/v1/payload_stats_controller_test.rb
@@ -12,4 +12,17 @@ class Api::V1::PayloadStatsControllerTest < ActionController::TestCase
     assert_equal "http://apple.com",   highest_most_recent["url"]
     assert_equal 2,                    highest_most_recent["visits"]
   end
+
+  test "#top_referrers" do
+    get :top_referrers, format: :json
+    top_referrers = JSON.parse(response.body)
+    most_recent = top_referrers[top_referrers.keys.first]
+    highest_most_recent = most_recent.first
+
+    assert_response :success
+    assert_equal 2,                    most_recent.size
+    assert_equal "http://apple.com",   highest_most_recent["url"]
+    assert_equal 2,                    highest_most_recent["visits"]
+    assert_equal 1,                    highest_most_recent["referrers"].size
+  end
 end

--- a/test/fixtures/payloads.yml
+++ b/test/fixtures/payloads.yml
@@ -2,7 +2,7 @@
 
 one:
   url: "http://apple.com"
-  referrer: nil
+  referrer: 
   payload_hash:
   created_at: '2015-04-29 01:35:23'
 

--- a/test/models/payload_stats_test.rb
+++ b/test/models/payload_stats_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class PayloadStatsTest < ActiveSupport::TestCase
+  attr_reader :payload
+
+  def setup
+    @payload = Payload.new(valid_attributes)
+  end
+
+  def valid_attributes
+    { url: "http://apple.com",
+      referrer: "http://store.apple.com/us",
+      created_at: Time.parse('2015-04-28') }
+  end
+
+  def payload_hash
+    Digest::MD5.hexdigest(payload_string)
+  end
+
+  def payload_string
+    output = "{id:#{payload.id}, url: '#{payload.url}', "
+    output += "referrer: '#{payload.referrer}', " if payload.referrer.present?
+    output += "created_at: '#{payload.created_at}'}"
+  end
+
+  test "it creates a payload with a referrer" do
+     payload.save
+
+     assert payload.valid?
+     assert_equal "http://apple.com",           payload.url
+     assert_equal "http://store.apple.com/us",  payload.referrer
+     assert_equal Time.parse('2015-04-28'),     payload.created_at
+     assert_equal payload_hash,                 payload.payload_hash
+  end
+
+  test "it can create a payload without a referrer" do
+     payload.referrer = nil
+     payload.save
+
+     assert payload.valid?
+     assert_equal "http://apple.com",        payload.url
+     assert_equal nil,                       payload.referrer
+     assert_equal Time.parse('2015-04-28'),  payload.created_at
+     assert_equal payload_hash,              payload.payload_hash
+  end
+
+  test "it can not create a payload without a url" do
+     payload.url = nil
+     assert payload.invalid?
+  end
+end

--- a/test/models/payload_test.rb
+++ b/test/models/payload_test.rb
@@ -1,51 +1,28 @@
 require 'test_helper'
 
 class PayloadTest < ActiveSupport::TestCase
-  attr_reader :payload
+  attr_reader :ps
 
   def setup
-    @payload = Payload.new(valid_attributes)
+    @ps = PayloadStats.new
   end
 
-  def valid_attributes
-    { url: "http://apple.com",
-      referrer: "http://store.apple.com/us",
-      created_at: Time.parse('2015-04-28') }
-  end
-  
-  def payload_hash
-    Digest::MD5.hexdigest(payload_string)
-  end
+  test "can produce top urls" do
+    top_urls = ps.top_urls
+    value = top_urls[top_urls.keys[0]][0]
 
-  def payload_string
-    output = "{id:#{payload.id}, url: '#{payload.url}', "
-    output += "referrer: '#{payload.referrer}', " if payload.referrer.present?
-    output += "created_at: '#{payload.created_at}'}"
+    assert_equal Date,               top_urls.keys[0].class
+    assert_equal "http://apple.com", value["url"]
+    assert_equal 2,                  value["visits"]
   end
 
-  test "it creates a payload with a referrer" do
-     payload.save
+  test "it can produce top referrers" do
+    top_referrers = ps.top_referrers
+    value = top_referrers[top_referrers.keys[0]][0]
 
-     assert payload.valid?
-     assert_equal "http://apple.com",           payload.url
-     assert_equal "http://store.apple.com/us",  payload.referrer
-     assert_equal Time.parse('2015-04-28'),     payload.created_at
-     assert_equal payload_hash,                 payload.payload_hash
-  end
-
-  test "it can create a payload without a referrer" do
-     payload.referrer = nil
-     payload.save
-
-     assert payload.valid?
-     assert_equal "http://apple.com",        payload.url
-     assert_equal nil,                       payload.referrer
-     assert_equal Time.parse('2015-04-28'),  payload.created_at
-     assert_equal payload_hash,              payload.payload_hash
-  end
-
-  test "it can not create a payload without a url" do
-     payload.url = nil
-     assert payload.invalid?
+    assert_equal Date,               top_referrers.keys[0].class
+    assert_equal "http://apple.com", value["url"]
+    assert_equal 2,                  value["visits"]
+    assert_equal 1,                  value["referrers"].size
   end
 end


### PR DESCRIPTION
Created the Top referrers enpoint which retrieves the top 5 referrers for the top 10 URLs grouped by day, for the past 5 days, via a REST endpoint.

Moved stats logic into a PORO class, PayloadStats

Tests pass 
![screen shot 2015-04-29 at 4 57 49 am](https://cloud.githubusercontent.com/assets/8313881/7389584/9facedc4-ee2c-11e4-863f-ae30811094a5.png)
